### PR TITLE
feat: improve accessibility labels

### DIFF
--- a/resources/views/components/forms/elements/switch.blade.php
+++ b/resources/views/components/forms/elements/switch.blade.php
@@ -29,6 +29,7 @@
         @click="toggled = !toggled"
         :class="toggled ? 'bg-theme' : 'bg-gray-300'"
         class="relative inline-flex items-center cursor-pointer {{ $sizeClasses['track'] }} rounded-full transition-colors duration-300 focus:outline-none"
+        aria-label="{{ $label ? strip_tags($label) : __tl('Basculer') }}"
     >
         <span
             :class="toggled ? '{{ $sizeClasses['translate'] }}' : 'translate-x-1'"

--- a/resources/views/components/layouts/modal.blade.php
+++ b/resources/views/components/layouts/modal.blade.php
@@ -9,7 +9,7 @@
             <div class="text-2xl" data-area="title">
                 @if($title) {{ $title }} @endif
             </div>
-            <a href="javascript:void(0);" @click="{{$ref}}Open=!{{$ref}}Open"><i class="text-2xl icon icon-times"></i></a>
+            <a href="javascript:void(0);" @click="{{$ref}}Open=!{{$ref}}Open" aria-label="{{ __tl('Fermer la fenêtre modale') }}"><i class="text-2xl icon icon-times"></i></a>
         </div>
         <div class="flex-1" data-area="content">
             {{ $slot }}

--- a/resources/views/components/utils/pagination.blade.php
+++ b/resources/views/components/utils/pagination.blade.php
@@ -14,13 +14,13 @@
         </div>
         <div class="flex items-center space-x-2">
 
-            <div class="p-2 font-light rounded-full text-md icon icon-chevron-left {{ $currentPage > 1 ? 'bg-theme text-white shadow-lg hover:opacity-90 cursor-pointer' : 'bg-gray-100 text-gray-400' }}" @click="paginate({{ $currentPage > 1 ? $currentPage - 1 : null }})"></div>
+            <button type="button" class="p-2 font-light rounded-full text-md icon icon-chevron-left {{ $currentPage > 1 ? 'bg-theme text-white shadow-lg hover:opacity-90 cursor-pointer' : 'bg-gray-100 text-gray-400' }}" @click="paginate({{ $currentPage > 1 ? $currentPage - 1 : null }})" aria-label="{{ __tl('Page précédente') }}"></button>
             @foreach (range(1, $totalPages) as $page)
                 @if( $currentPage > $page - 3 && $currentPage < $page + 3 )
-                    <div class="py-2 rounded-full text-xs leading-3 w-7 text-center font-normal {{ $currentPage == $page ? 'bg-theme text-white' : 'bg-gray-100 hover:bg-gray-100 cursor-pointer' }}" @click="paginate({{ $page }})">{{ $page }}</div>
+                    <button type="button" class="py-2 rounded-full text-xs leading-3 w-7 text-center font-normal {{ $currentPage == $page ? 'bg-theme text-white' : 'bg-gray-100 hover:bg-gray-100 cursor-pointer' }}" @click="paginate({{ $page }})">{{ $page }}</button>
                 @endif
             @endforeach
-            <div class="p-2 font-light rounded-full text-md icon icon-chevron-right {{ $currentPage < $totalPages ? 'bg-theme text-white shadow-lg hover:opacity-90 cursor-pointer' : 'bg-gray-100 text-gray-400' }}" @click="paginate({{ $currentPage < $totalPages ? $currentPage + 1 : null }})"></div>
+            <button type="button" class="p-2 font-light rounded-full text-md icon icon-chevron-right {{ $currentPage < $totalPages ? 'bg-theme text-white shadow-lg hover:opacity-90 cursor-pointer' : 'bg-gray-100 text-gray-400' }}" @click="paginate({{ $currentPage < $totalPages ? $currentPage + 1 : null }})" aria-label="{{ __tl('Page suivante') }}"></button>
 
         </div>
     </div>

--- a/resources/views/components/vehicles/card.blade.php
+++ b/resources/views/components/vehicles/card.blade.php
@@ -8,7 +8,7 @@ $model_link = localized_route('pages.vehicles.detail.model', [
     <div class="flex flex-col">
         <div class="flex flex-col md:flex-row">
             <div class="relative md:max-w-xs">
-                <a href="javascript:void(0)" class="absolute p-1 text-white bg-black rounded-full icon icon-camera bottom-3 right-3"></a>
+                <a href="javascript:void(0)" class="absolute p-1 text-white bg-black rounded-full icon icon-camera bottom-3 right-3" aria-label="{{ __tl('Ouvrir la galerie') }}"></a>
                 <a href="{{ $model_link }}"><img src="{{ $vehicle['model']['mainImage']['image400'] }}" class="object-cover w-full aspect-3/2"></a>
             </div>
             <div class="flex flex-col flex-1 gap-2 p-4">

--- a/resources/views/components/vehicles/colors-buttons.blade.php
+++ b/resources/views/components/vehicles/colors-buttons.blade.php
@@ -17,10 +17,13 @@
         data-value="{{ $color['code'] }}"
         data-image="{{ $color['colorImage']['image800'] ?? '' }}"
         data-color-type="{{ $color['colorType'] ?? 'other' }}"
+        role="button"
+        tabindex="0"
+        aria-label="{{$color['description']}} - {{$color['group']}}"
         @click="select"></span>
     @endforeach
     @if(count($colors) > 4)
-        <span class="flex items-center justify-center w-12 h-12 border-4 border-white rounded-full cursor-pointer outline-2 outline-gray-100" @click="showAll=!showAll"><i class="text-2xl icon " :class="showAll ? 'icon-minus' : 'icon-plus'"></i></span>
+        <button type="button" class="flex items-center justify-center w-12 h-12 border-4 border-white rounded-full cursor-pointer outline-2 outline-gray-100" @click="showAll=!showAll" :aria-label="showAll ? @js(__tl('Masquer les couleurs')) : @js(__tl('Afficher toutes les couleurs'))"><i class="text-2xl icon " :class="showAll ? 'icon-minus' : 'icon-plus'"></i></button>
     @endif
 </div>
 <script>

--- a/resources/views/components/vehicles/gallery.blade.php
+++ b/resources/views/components/vehicles/gallery.blade.php
@@ -43,7 +43,7 @@
                 @foreach ($images as $image)
                     @if(isset($image['image800']))
                         <div class="slide-item relative h-full" :class="expanded ? 'w-screen flex items-center' : 'aspect-9/16 md:aspect-4/3 w-full'">
-                            <a href="javascript:void(0)" class="absolute p-1 text-white bg-black rounded-full icon top-3 right-3" :class="expanded ? 'icon-times text-3xl fixed top-4 right-4' : 'icon-expand'" @click="( expanded ? collapse(event) : expand(event) ) "></a>
+                            <a href="javascript:void(0)" class="absolute p-1 text-white bg-black rounded-full icon top-3 right-3" :class="expanded ? 'icon-times text-3xl fixed top-4 right-4' : 'icon-expand'" @click="( expanded ? collapse(event) : expand(event) )" :aria-label="expanded ? @js(__tl('Fermer la galerie')) : @js(__tl('Agrandir l\'image'))"></a>
                             <img src="{{ $image['image800'] }}" loading="lazy" class="w-full h-full snap-center" @click="expand" :class="expanded ? 'object-contain max-h-[80vh]' : 'object-cover'">
                         </div>
                     @endif
@@ -52,8 +52,8 @@
             </div>
         </div>
         <div class="flex items-center justify-center max-w-screen-xl gap-4 px-4 mx-auto mt-4">
-            <div class="p-2 font-light rounded-full shadow-lg cursor-pointer text-md icon icon-chevron-left hover:opacity-90" @click="back" :class="expanded ? 'text-3xl' : 'bg-white'"></div>
-            <div class="p-2 font-light rounded-full shadow-lg cursor-pointer text-md icon icon-chevron-right hover:opacity-90" @click="next" :class="expanded ? 'text-3xl' : 'bg-white'"></div>
+            <button type="button" class="p-2 font-light rounded-full shadow-lg cursor-pointer text-md icon icon-chevron-left hover:opacity-90" @click="back" :class="expanded ? 'text-3xl' : 'bg-white'" aria-label="{{ __tl('Image précédente') }}"></button>
+            <button type="button" class="p-2 font-light rounded-full shadow-lg cursor-pointer text-md icon icon-chevron-right hover:opacity-90" @click="next" :class="expanded ? 'text-3xl' : 'bg-white'" aria-label="{{ __tl('Image suivante') }}"></button>
         </div>
     </div>
 @endif

--- a/resources/views/pages/vehicles/detail-model.blade.php
+++ b/resources/views/pages/vehicles/detail-model.blade.php
@@ -189,8 +189,8 @@ $breadcrumb = [
                 </div>
             </div>
             <div class="flex items-center justify-center max-w-screen-xl gap-4 px-4 mx-auto mt-0">
-                <div class="p-2 font-light rounded-full shadow-lg cursor-pointer text-md icon icon-chevron-left hover:opacity-90" @click="back" :class="expanded ? 'text-3xl' : 'bg-white'"></div>
-                <div class="p-2 font-light rounded-full shadow-lg cursor-pointer text-md icon icon-chevron-right hover:opacity-90" @click="next" :class="expanded ? 'text-3xl' : 'bg-white'"></div>
+                <button type="button" class="p-2 font-light rounded-full shadow-lg cursor-pointer text-md icon icon-chevron-left hover:opacity-90" @click="back" :class="expanded ? 'text-3xl' : 'bg-white'" aria-label="{{ __tl('Précédent') }}"></button>
+                <button type="button" class="p-2 font-light rounded-full shadow-lg cursor-pointer text-md icon icon-chevron-right hover:opacity-90" @click="next" :class="expanded ? 'text-3xl' : 'bg-white'" aria-label="{{ __tl('Suivant') }}"></button>
             </div>
         </div>
     </div>

--- a/resources/views/pages/vehicles/search.blade.php
+++ b/resources/views/pages/vehicles/search.blade.php
@@ -78,7 +78,7 @@ $breadcrumb = [
 
                     <div x-data="{ shown : false }" x-intersect:leave="shown = true" x-intersect:enter="shown = false">
                         <div x-show="shown" class="fixed z-20 bottom-4 right-3 md:hidden" x-transition>
-                            <div class="p-3 text-xl font-light bg-white border-gray-100 rounded-full shadow-lg border-1 icon icon-filter" @click="filtersOpen=true"></div>
+                            <button type="button" class="p-3 text-xl font-light bg-white border-gray-100 rounded-full shadow-lg border-1 icon icon-filter" @click="filtersOpen=true" aria-label="{{ __tl('Afficher les filtres') }}"></button>
                         </div>
                     </div>
 

--- a/resources/views/partials/vehicles/search/filters.blade.php
+++ b/resources/views/partials/vehicles/search/filters.blade.php
@@ -1,7 +1,7 @@
 <div class="pb-8">
     <div class="flex items-center justify-between py-4 md:hidden">
         <div class="text-2xl">{{ __tl('Filtres') }}</div>
-        <a href="javascript:void(0);" @click="filtersOpen=!filtersOpen"><i class="text-2xl icon icon-times"></i></a>
+        <a href="javascript:void(0);" @click="filtersOpen=!filtersOpen" aria-label="{{ __tl('Fermer les filtres') }}"><i class="text-2xl icon icon-times"></i></a>
     </div>
     <div class="flex justify-end my-4">
         <a href="?" class="text-xs font-semibold underline">{{ __tl('Supprimer tous les filtres ') }}<i class="icon icon-times"></i></a>

--- a/resources/views/vendor/filament-panels/components/sidebar/group.blade.php
+++ b/resources/views/vendor/filament-panels/components/sidebar/group.blade.php
@@ -87,6 +87,7 @@
                     "
                     x-tooltip.html="tooltip"
                     class="relative flex flex-1 items-center justify-center gap-x-3 rounded-lg px-2 py-2 outline-none transition duration-75 hover:bg-gray-100 focus-visible:bg-gray-100 dark:hover:bg-white/5 dark:focus-visible:bg-white/5"
+                    aria-label="{{ $label }}"
                 >
                     <x-filament::icon
                         :icon="$icon"

--- a/resources/views/vendor/filament-panels/components/tenant-menu.blade.php
+++ b/resources/views/vendor/filament-panels/components/tenant-menu.blade.php
@@ -54,6 +54,7 @@
             @endif
             type="button"
             class="fi-tenant-menu-trigger group flex w-full items-center justify-center gap-x-3 rounded-lg p-2 text-sm font-medium outline-none transition duration-75 hover:bg-gray-100 focus-visible:bg-gray-100 dark:hover:bg-white/5 dark:focus-visible:bg-white/5"
+            aria-label="{{ __('filament-panels::layout.actions.open_tenant_menu.label') }}"
         >
             <x-filament-panels::avatar.tenant
                 :tenant="$currentTenant"


### PR DESCRIPTION
## Summary
- add aria-labels to modal close buttons and vehicle gallery controls
- ensure navigation and pagination icons have clear labels
- add accessible labels to color selectors and filter toggles

## Testing
- `composer test` *(fails: Expected response status code [200] but received 302)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1638fb48832ba8db47e8d7ab0dbe