### PR TITLE
Refactor action links to buttons for accessibility

### DIFF
--- a/resources/views/components/layouts/header.blade.php
+++ b/resources/views/components/layouts/header.blade.php
@@ -41,10 +41,10 @@ x-data="{
             <input x-ref="inpGlobalSearch" class="self-stretch flex-1 text-sm border-0 outline-0" name="inp_global_search" placeholder="{{ __tl('Recherche par marques, modèle ou mot-clé') }}" @keyup.enter="globalSearch($event.target.value)" @keyup.esc="toggleGlobalSearch" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
         </div>
         <div class="order-2 mx-2 md:order-3">
-            <a href="javascript:void(0);" @Click="toggleGlobalSearch" class="hover:text-theme"><span class="text-xl icon" :class="globalSearchOpen ? 'icon-times' : 'icon-search'"></span></a>
+            <button type="button" @click="toggleGlobalSearch" class="hover:text-theme"><span class="text-xl icon" :class="globalSearchOpen ? 'icon-times' : 'icon-search'"></span></button>
         </div>
         <div class="order-3 mx-2 md:order-4" x-show="!globalSearchOpen">
-            <a href="javascript:void(0);" x-on:click="navOpen = ! navOpen" class="hover:text-theme"><span class="text-xl icon" :class="navOpen ? 'icon-times' : 'icon-burger'"></span></a>
+            <button type="button" x-on:click="navOpen = ! navOpen" class="hover:text-theme"><span class="text-xl icon" :class="navOpen ? 'icon-times' : 'icon-burger'"></span></button>
         </div>
         <div x-show="navOpen && !globalSearchOpen" x-cloak>
             <ul class="fixed bottom-0 right-0 z-10 flex flex-col w-full gap-3 px-8 py-6 transition-all duration-300 ease-in-out bg-white border-b border-gray-200 shadow-xl md:absolute md:bottom-auto justify-top md:border top-18 nowrap md:w-auto md:top-24 md:text-sm">
@@ -57,8 +57,8 @@ x-data="{
                 <li><a href="{{ localized_route('pages.elements') }}" class="hover:text-theme">Elements UIUX</a></li>
                 <li><a href="/assets/fonts/fleetmarket.v1.1/icons-reference.html" class="hover:text-theme">Icons</a></li>
                 <li class="flex items-end flex-1 gap-2">
-                    <a href="javascript:void(0);" onclick="window.changeLang('fr')" class="flex-1 text-center text-sm rounded-full px-4 py-2 border-1 {{ app()->getLocale() == 'fr' ? 'font-semibold' : 'font-normal border-gray-200' }}">Français</a>
-                    <a href="javascript:void(0);" onclick="window.changeLang('nl')" class="flex-1 text-center text-sm rounded-full px-4 py-2 border-1 {{ app()->getLocale() == 'nl' ? 'font-semibold' : 'font-normal border-gray-200' }}">Nederlands</a>
+                    <button type="button" onclick="window.changeLang('fr')" class="flex-1 text-center text-sm rounded-full px-4 py-2 border-1 {{ app()->getLocale() == 'fr' ? 'font-semibold' : 'font-normal border-gray-200' }}">Français</button>
+                    <button type="button" onclick="window.changeLang('nl')" class="flex-1 text-center text-sm rounded-full px-4 py-2 border-1 {{ app()->getLocale() == 'nl' ? 'font-semibold' : 'font-normal border-gray-200' }}">Nederlands</button>
                 </li>
             </ul>
         </div>

--- a/resources/views/components/layouts/modal.blade.php
+++ b/resources/views/components/layouts/modal.blade.php
@@ -9,7 +9,7 @@
             <div class="text-2xl" data-area="title">
                 @if($title) {{ $title }} @endif
             </div>
-            <a href="javascript:void(0);" @click="{{$ref}}Open=!{{$ref}}Open"><i class="text-2xl icon icon-times"></i></a>
+            <button type="button" @click="{{$ref}}Open=!{{$ref}}Open"><i class="text-2xl icon icon-times"></i></button>
         </div>
         <div class="flex-1" data-area="content">
             {{ $slot }}

--- a/resources/views/components/utils/button.blade.php
+++ b/resources/views/components/utils/button.blade.php
@@ -4,7 +4,7 @@
     "disabled" => false,
     "size" => 'md',
     "color" => 'dark',
-    "url" => "javascript:void(0);",
+    "url" => null,
     "icon" => null,
     "rIcon" => null,
     "align" => ''
@@ -62,6 +62,7 @@ switch ($size) {
     break;
 }
 @endphp
+@if($url)
 <a href="{{ $url }}" {{ $attributes->merge(['class' => $def_class]) }}>
     <div class="flex items-center justify-center h-full">
         @if($icon ?? false)
@@ -73,4 +74,17 @@ switch ($size) {
         @endif
     </div>
 </a>
+@else
+<button type="button" {{ $attributes->merge(['class' => $def_class]) }}>
+    <div class="flex items-center justify-center h-full">
+        @if($icon ?? false)
+            <div class="align-middle {{ $def_class_icon }}"><i class="icon {{ $icon }} inline-block"></i></div>
+        @endif
+        <div class="{{ $align == 'center' ? 'flex-1' : ''}} {{ $align == 'left' ? 'flex-1 text-left' : ''}} {{ $align == 'right' ? 'flex-1 text-right' : ''}}">{!! $label ?? $slot !!}</div>
+        @if($rIcon ?? false)
+            <div class="align-middle {{ $def_class_r_icon }}"><i class="icon {{ $rIcon }} inline-block"></i></div>
+        @endif
+    </div>
+</button>
+@endif
 

--- a/resources/views/components/utils/label.blade.php
+++ b/resources/views/components/utils/label.blade.php
@@ -2,7 +2,6 @@
     "label" => null,
     "color" => 'dark',
     "size" => 'xs',
-    "url" => "javascript:void(0);",
     "icon" => null,
     "rIcon" => null,
 ])

--- a/resources/views/components/vehicles/card.blade.php
+++ b/resources/views/components/vehicles/card.blade.php
@@ -8,7 +8,7 @@ $model_link = localized_route('pages.vehicles.detail.model', [
     <div class="flex flex-col">
         <div class="flex flex-col md:flex-row">
             <div class="relative md:max-w-xs">
-                <a href="javascript:void(0)" class="absolute p-1 text-white bg-black rounded-full icon icon-camera bottom-3 right-3"></a>
+                <button type="button" class="absolute p-1 text-white bg-black rounded-full icon icon-camera bottom-3 right-3"></button>
                 <a href="{{ $model_link }}"><img src="{{ $vehicle['model']['mainImage']['image400'] }}" class="object-cover w-full aspect-3/2"></a>
             </div>
             <div class="flex flex-col flex-1 gap-2 p-4">
@@ -63,7 +63,7 @@ $model_link = localized_route('pages.vehicles.detail.model', [
                     </div>
                 @endif
                 <div class="flex flex-col items-center gap-2 pt-4 border-t border-gray-100 md:justify-end md:flex-row">
-                    <div class="md:flex-1"><a href="javascript:void(0);" onclick="window.unavailable()" class="text-xs font-semibold underline">{{ __tl('Comparer avec un autre vehicule') }}</a></div>
+                    <div class="md:flex-1"><button type="button" onclick="window.unavailable()" class="text-xs font-semibold underline">{{ __tl('Comparer avec un autre vehicule') }}</button></div>
                     {{--<x-utils.button label="Comparer" size="md" icon="icon-car-compare" color="bordered"></x-utils.button>--}}
                     <x-utils.button label="{{ __tl('En savoir plus') }}" size="sm" icon="icon-info-circle" r-icon="icon-chevron-right" color="theme" class="flex-1 md:flex-none" url="{{ $model_link }}"></x-utils.button>
                 </div>

--- a/resources/views/components/vehicles/gallery.blade.php
+++ b/resources/views/components/vehicles/gallery.blade.php
@@ -43,7 +43,7 @@
                 @foreach ($images as $image)
                     @if(isset($image['image800']))
                         <div class="slide-item relative h-full" :class="expanded ? 'w-screen flex items-center' : 'aspect-9/16 md:aspect-4/3 w-full'">
-                            <a href="javascript:void(0)" class="absolute p-1 text-white bg-black rounded-full icon top-3 right-3" :class="expanded ? 'icon-times text-3xl fixed top-4 right-4' : 'icon-expand'" @click="( expanded ? collapse(event) : expand(event) ) "></a>
+                            <button type="button" class="absolute p-1 text-white bg-black rounded-full icon top-3 right-3" :class="expanded ? 'icon-times text-3xl fixed top-4 right-4' : 'icon-expand'" @click="( expanded ? collapse(event) : expand(event) ) "></button>
                             <img src="{{ $image['image800'] }}" loading="lazy" class="w-full h-full snap-center" @click="expand" :class="expanded ? 'object-contain max-h-[80vh]' : 'object-cover'">
                         </div>
                     @endif

--- a/resources/views/pages/vehicles/compare.blade.php
+++ b/resources/views/pages/vehicles/compare.blade.php
@@ -9,7 +9,7 @@ $breadcrumb = [
     <x-utils.container>
         <h1 class="h1">Comparer véhicules</h1>
         <p><i>{{ __tl('Bientôt disponible...') }}</i></p>
-        <a href="javascript:void(0);" onclick="window.comparator.openModal()">Lancer le comparateur</a>
+        <button type="button" onclick="window.comparator.openModal()">Lancer le comparateur</button>
         <x-layouts.modal ref="comparatorModal" id="comparator-modal"></x-layouts.modal>
     </x-utils.container>
 

--- a/resources/views/pages/vehicles/configurator.blade.php
+++ b/resources/views/pages/vehicles/configurator.blade.php
@@ -90,8 +90,8 @@ $versionHistoricalId = $versionHistoricalId ?? $motors->first()['versionHistoric
                         </p>
                     </div>
                     <div class="flex flex-col items-end justify-end order-3 w-full py-2 md:order-2 md:w-auto">
-                        <a href="javascript:void(0);" onclick="window.unavailable()" class="text-xs underline">{{ __tl('Comparer des modèles') }}<i class="ml-2 text-xl icon icon-eye"></i></a>
-                        <a href="javascript:void(0);" onclick="window.unavailable()" class="text-xs underline">{{ __tl('Sauvegarder la configuration') }}<i class="ml-2 text-xl icon icon-bookmark"></i></a>
+                        <button type="button" onclick="window.unavailable()" class="text-xs underline">{{ __tl('Comparer des modèles') }}<i class="ml-2 text-xl icon icon-eye"></i></button>
+                        <button type="button" onclick="window.unavailable()" class="text-xs underline">{{ __tl('Sauvegarder la configuration') }}<i class="ml-2 text-xl icon icon-bookmark"></i></button>
                     </div>
                     <img src="{{ $make['logo'] }}" class="self-start order-2 w-20 md:w-24 md:order-3" alt="{{ $vehicle['model']['makeName'] }} logo">
                 </div>
@@ -561,19 +561,19 @@ window.configurator = {
             }
 
             content += `<div class="flex mt-4">
-                <div><a href="javascript:void(0);" class="inline-block w-full max-w-sm px-6 py-3 text-sm font-normal text-center transition-all duration-200 ease-in-out bg-gray-200 rounded-full hover:opacity-90" onclick="window.configurator.rejectAlternative()">
+                <div><button type="button" class="inline-block w-full max-w-sm px-6 py-3 text-sm font-normal text-center transition-all duration-200 ease-in-out bg-gray-200 rounded-full hover:opacity-90" onclick="window.configurator.rejectAlternative()">
                     <span class="flex items-center justify-center h-full">
                         <span class="mr-2 -ml-3 align-middle"><i class="inline-block icon icon-ban"></i></span>
                         <span>{{ __tl('Annuler') }}</span>
                     </span>
-                </a></div>
+                </button></div>
                 <div class="flex-1"></div>
-                <div><a href="javascript:void(0);" class="inline-block w-full max-w-sm px-6 py-3 text-sm text-center text-white transition-all duration-200 ease-in-out rounded-full hover:opacity-90 bg-theme" onclick="window.configurator.acceptAlternative()">
+                <div><button type="button" class="inline-block w-full max-w-sm px-6 py-3 text-sm text-center text-white transition-all duration-200 ease-in-out rounded-full hover:opacity-90 bg-theme" onclick="window.configurator.acceptAlternative()">
                     <span class="flex items-center justify-center h-full">
                         <span class="mr-2 -ml-3 align-middle"><i class="inline-block icon icon-check-circle"></i></span>
                         <span>{{ __tl('Accepter') }}</span>
                     </span>
-                </a></div>
+                </button></div>
                 </div>`;
             window.xMainData.optionsModalOpen = true;
             modal.querySelector('[data-area="content"]').innerHTML = content;

--- a/resources/views/pages/vehicles/search.blade.php
+++ b/resources/views/pages/vehicles/search.blade.php
@@ -90,12 +90,12 @@ $breadcrumb = [
 
                     <x-layouts.modal title="{{ __tl('Trier les vehicules par ?') }}" ref="suggestions" id="suggestions-modal">
                         <div class="flex flex-col">
-                            <a href="javascript:void(0);" data-sort="" data-label="Recommandation" class="py-3 border-b border-gray-100">{{ __tl('Nos recommandations') }}</a>
-                            {{-- <a href="javascript:void(0);" data-sort="minPrice asc" data-label="Meilleurs ventes" class="py-3 border-b border-gray-100">Meilleurs ventes</a> --}}
-                            <a href="javascript:void(0);" data-sort="minPrice asc" data-label="Les plus économiques" class="py-3 border-b border-gray-100">{{ __tl('Du plus économique au plus cher') }}</a>
-                            <a href="javascript:void(0);" data-sort="minPrice desc" data-label="Les plus chers" class="py-3 border-b border-gray-100">{{ __tl('Du plus cher au plus économique') }}</a>
-                            <a href="javascript:void(0);" data-sort="modelName asc" data-label="A-Z" class="py-3 border-b border-gray-100">{{ __tl('De A-Z') }}</a>
-                            <a href="javascript:void(0);" data-sort="modelName desc" data-label="Z-A" class="py-3">{{ __tl('De Z-A') }}</a>
+                            <button type="button" data-sort="" data-label="Recommandation" class="py-3 border-b border-gray-100 text-left w-full">{{ __tl('Nos recommandations') }}</button>
+                            {{-- <button type="button" data-sort="minPrice asc" data-label="Meilleurs ventes" class="py-3 border-b border-gray-100">Meilleurs ventes</button> --}}
+                            <button type="button" data-sort="minPrice asc" data-label="Les plus économiques" class="py-3 border-b border-gray-100 text-left w-full">{{ __tl('Du plus économique au plus cher') }}</button>
+                            <button type="button" data-sort="minPrice desc" data-label="Les plus chers" class="py-3 border-b border-gray-100 text-left w-full">{{ __tl('Du plus cher au plus économique') }}</button>
+                            <button type="button" data-sort="modelName asc" data-label="A-Z" class="py-3 border-b border-gray-100 text-left w-full">{{ __tl('De A-Z') }}</button>
+                            <button type="button" data-sort="modelName desc" data-label="Z-A" class="py-3 text-left w-full">{{ __tl('De Z-A') }}</button>
                         </div>
                     </x-layouts.modal>
 

--- a/resources/views/partials/vehicles/search/filters.blade.php
+++ b/resources/views/partials/vehicles/search/filters.blade.php
@@ -1,7 +1,7 @@
 <div class="pb-8">
     <div class="flex items-center justify-between py-4 md:hidden">
         <div class="text-2xl">{{ __tl('Filtres') }}</div>
-        <a href="javascript:void(0);" @click="filtersOpen=!filtersOpen"><i class="text-2xl icon icon-times"></i></a>
+        <button type="button" @click="filtersOpen=!filtersOpen"><i class="text-2xl icon icon-times"></i></button>
     </div>
     <div class="flex justify-end my-4">
         <a href="?" class="text-xs font-semibold underline">{{ __tl('Supprimer tous les filtres ') }}<i class="icon icon-times"></i></a>


### PR DESCRIPTION
## Summary
- replace `javascript:void(0)` anchors with semantic `<button>` elements
- update button component to render `<button>` when no URL is provided
- remove dummy action links in headers and modals

## Testing
- `php artisan test` *(fails: Expected response status code [200] but received 302)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1f5078a8832ba59f020f9c4a4622