### PR TITLE
Improve gallery accessibility

### DIFF
--- a/resources/views/components/vehicles/gallery.blade.php
+++ b/resources/views/components/vehicles/gallery.blade.php
@@ -37,14 +37,14 @@
                     });
                 }
             }
-        }" class="flex flex-col py-6" :class="expanded ? 'fixed bg-black text-white top-0 left-0 right-0 bottom-0 z-100 h-screen w-screen' : 'bg-gray-50'">
+        }" class="flex flex-col py-6" :class="expanded ? 'fixed bg-black text-white top-0 left-0 right-0 bottom-0 z-100 h-screen w-screen' : 'bg-gray-50'" @keydown.window.arrow-left="back" @keydown.window.arrow-right="next" @keydown.window.escape="collapse">
         <div class="flex-1 max-w-full overflow-auto cursor-pointer select-none snap-x snap-mandatory scrollbar-hide" style="-ms-overflow-style: none; scrollbar-width: none;" >
             <div class="flex flex-nowrap" :class="expanded ? 'w-screen h-full' : 'gap-3 px-4 h-120 md:h-96'" style="width:fit-content;">
                 @foreach ($images as $image)
                     @if(isset($image['image800']))
                         <div class="slide-item relative h-full" :class="expanded ? 'w-screen flex items-center' : 'aspect-9/16 md:aspect-4/3 w-full'">
-                            <a href="javascript:void(0)" class="absolute p-1 text-white bg-black rounded-full icon top-3 right-3" :class="expanded ? 'icon-times text-3xl fixed top-4 right-4' : 'icon-expand'" @click="( expanded ? collapse(event) : expand(event) ) "></a>
-                            <img src="{{ $image['image800'] }}" loading="lazy" class="w-full h-full snap-center" @click="expand" :class="expanded ? 'object-contain max-h-[80vh]' : 'object-cover'">
+                            <button type="button" class="absolute p-1 text-white bg-black rounded-full icon top-3 right-3" :class="expanded ? 'icon-times text-3xl fixed top-4 right-4' : 'icon-expand'" @click="( expanded ? collapse(event) : expand(event) )" :aria-label="expanded ? 'Fermer la vue agrandie' : 'Agrandir l\'image'"></button>
+                            <img src="{{ $image['image800'] }}" loading="lazy" class="w-full h-full snap-center" @click="expand" @keyup.enter="expanded ? collapse(event) : expand(event)" :class="expanded ? 'object-contain max-h-[80vh]' : 'object-cover'" tabindex="0">
                         </div>
                     @endif
                 @endforeach
@@ -52,8 +52,8 @@
             </div>
         </div>
         <div class="flex items-center justify-center max-w-screen-xl gap-4 px-4 mx-auto mt-4">
-            <div class="p-2 font-light rounded-full shadow-lg cursor-pointer text-md icon icon-chevron-left hover:opacity-90" @click="back" :class="expanded ? 'text-3xl' : 'bg-white'"></div>
-            <div class="p-2 font-light rounded-full shadow-lg cursor-pointer text-md icon icon-chevron-right hover:opacity-90" @click="next" :class="expanded ? 'text-3xl' : 'bg-white'"></div>
+            <button type="button" class="p-2 font-light rounded-full shadow-lg cursor-pointer text-md icon icon-chevron-left hover:opacity-90" @click="back" :class="expanded ? 'text-3xl' : 'bg-white'" aria-label="Image précédente"></button>
+            <button type="button" class="p-2 font-light rounded-full shadow-lg cursor-pointer text-md icon icon-chevron-right hover:opacity-90" @click="next" :class="expanded ? 'text-3xl' : 'bg-white'" aria-label="Image suivante"></button>
         </div>
     </div>
 @endif


### PR DESCRIPTION
## Summary
- replace gallery controls with semantic `<button>` elements and add `aria-label`s
- enable keyboard navigation for next/previous images and closing expanded view
- allow toggling expanded view via Enter key

## Testing
- `composer test` *(fails: Expected response status code [200] but received 302)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1f560c4c832bb551a46983081213