### PR TITLE
Add ARIA attributes for toggle buttons

### DIFF
--- a/resources/views/components/forms/elements/switch.blade.php
+++ b/resources/views/components/forms/elements/switch.blade.php
@@ -7,6 +7,7 @@
     'size' => 'md',
     'xInit' => null,
     'xEffect' => null,
+    'control' => null,
 ])
 
 @php
@@ -27,6 +28,8 @@
     <button
         type="button"
         @click="toggled = !toggled"
+        :aria-expanded="toggled.toString()"
+        @if($control) aria-controls="{{ $control }}" @endif
         :class="toggled ? 'bg-theme' : 'bg-gray-300'"
         class="relative inline-flex items-center cursor-pointer {{ $sizeClasses['track'] }} rounded-full transition-colors duration-300 focus:outline-none"
     >

--- a/resources/views/components/layouts/header.blade.php
+++ b/resources/views/components/layouts/header.blade.php
@@ -41,12 +41,12 @@ x-data="{
             <input x-ref="inpGlobalSearch" class="self-stretch flex-1 text-sm border-0 outline-0" name="inp_global_search" placeholder="{{ __tl('Recherche par marques, modèle ou mot-clé') }}" @keyup.enter="globalSearch($event.target.value)" @keyup.esc="toggleGlobalSearch" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
         </div>
         <div class="order-2 mx-2 md:order-3">
-            <a href="javascript:void(0);" @Click="toggleGlobalSearch" class="hover:text-theme"><span class="text-xl icon" :class="globalSearchOpen ? 'icon-times' : 'icon-search'"></span></a>
+            <a href="javascript:void(0);" @Click="toggleGlobalSearch" :aria-expanded="globalSearchOpen.toString()" aria-controls="global-search" class="hover:text-theme"><span class="text-xl icon" :class="globalSearchOpen ? 'icon-times' : 'icon-search'"></span></a>
         </div>
         <div class="order-3 mx-2 md:order-4" x-show="!globalSearchOpen">
-            <a href="javascript:void(0);" x-on:click="navOpen = ! navOpen" class="hover:text-theme"><span class="text-xl icon" :class="navOpen ? 'icon-times' : 'icon-burger'"></span></a>
+            <a href="javascript:void(0);" x-on:click="navOpen = ! navOpen" :aria-expanded="navOpen.toString()" aria-controls="nav-menu" class="hover:text-theme"><span class="text-xl icon" :class="navOpen ? 'icon-times' : 'icon-burger'"></span></a>
         </div>
-        <div x-show="navOpen && !globalSearchOpen" x-cloak>
+        <div x-show="navOpen && !globalSearchOpen" x-cloak id="nav-menu">
             <ul class="fixed bottom-0 right-0 z-10 flex flex-col w-full gap-3 px-8 py-6 transition-all duration-300 ease-in-out bg-white border-b border-gray-200 shadow-xl md:absolute md:bottom-auto justify-top md:border top-18 nowrap md:w-auto md:top-24 md:text-sm">
                 <li><a href="{{ localized_route('pages.home') }}" class="hover:text-theme">{{ __tl('Actualités') }}</a></li>
                 <li><a href="{{ localized_route('pages.vehicles.search') }}" class="hover:text-theme">{{ __tl('Rechercher') }}</a></li>

--- a/resources/views/partials/vehicles/configurator/options.blade.php
+++ b/resources/views/partials/vehicles/configurator/options.blade.php
@@ -10,9 +10,10 @@
     },
     options: [],
  }">
-    <x-forms.elements.switch class="flex-row-reverse mb-3 text-sm" name="inp_display_standard" label="{{ __tl('Afficher l\'équipement standard') }}" value="1" size="sm" checked
+    <x-forms.elements.switch class="flex-row-reverse mb-3 text-sm" name="inp_display_standard" label="{{ __tl('Afficher l\'équipement standard') }}" value="1" size="sm" checked control="equipment-options"
     x-init="$watch(`toggled`, value => showStandard = value)"
     x-effect="toggled = showStandard"/>
+    <div id="equipment-options">
     <template x-for="(eqSection, eqSectionKey) in options" :key="eqSectionKey">
         <details x-show="showStandard || Object.values(eqSection).some(sub => sub.some(e => e.type !== 'STANDARD'))">
             <summary class="pl-6 -ml-4 font-bold text-gray-800" x-text="eqSectionKey"></summary>
@@ -41,4 +42,5 @@
             </div>
         </details>
     </template>
+    </div>
 </div>

--- a/resources/views/partials/vehicles/contact/form.blade.php
+++ b/resources/views/partials/vehicles/contact/form.blade.php
@@ -189,9 +189,9 @@
                     </x-utils.box>
                 </div>
                 <div class="flex-1">
-                    <x-forms.elements.switch class="mb-2 text-sm" name="inp_display_message" label="Ajouter un message" value="1" x-init="$watch(`toggled`, value => showMessage = value)"
+                    <x-forms.elements.switch class="mb-2 text-sm" name="inp_display_message" label="Ajouter un message" value="1" control="contact-message" x-init="$watch(`toggled`, value => showMessage = value)"
                     x-effect="toggled = showMessage"/>
-                    <textarea name="inp_message" class="w-full h-24 px-4 py-3 text-sm font-normal border-gray-300 border-1 focus:outline-none text-theme placeholder:text-gray-500" placeholder="Message" x-show="showMessage"></textarea>
+                    <textarea id="contact-message" name="inp_message" class="w-full h-24 px-4 py-3 text-sm font-normal border-gray-300 border-1 focus:outline-none text-theme placeholder:text-gray-500" placeholder="Message" x-show="showMessage"></textarea>
                 </div>
                 <div class="flex-1 text-xs">
                     {{ __tl('En validant le formulaire, j\'accepte la') }} <a href="{{ localized_route('pages.legals') }}" class="underline" target="_blank">{{ __tl('Politique de confidentialité') }}</a> {{ __tl('et d\'être contacté(e) pour recevoir la prestation du service sollicité.') }}


### PR DESCRIPTION
## Summary
- ensure switch component exposes aria attributes for toggled content
- apply dynamic aria-expanded and aria-controls to global search, navigation, and form toggles

## Testing
- `npm test` *(fails: Missing script "test")*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1f57e20c832ba5c6ef314d78d9f5